### PR TITLE
Articleslist request filters object

### DIFF
--- a/src/app/actions/articleActions.js
+++ b/src/app/actions/articleActions.js
@@ -11,8 +11,9 @@ const ROOT_URL = 'https://socratiq-app.appspot.com';
 export function fetchArticles(filters, token) {
 	let request = {
     method: 'get',
-    url: filters.tag ? `${ROOT_URL}/tags/${filters.tag}/articles` : `${ROOT_URL}/articles`,
-		withCredentials: true
+    url: `${ROOT_URL}/articles`,
+		withCredentials: true,
+    params: filters
   };
 
 	if (token) {

--- a/src/app/actions/articleActions.js
+++ b/src/app/actions/articleActions.js
@@ -9,16 +9,16 @@ import {
 const ROOT_URL = 'https://socratiq-app.appspot.com';
 
 export function fetchArticles(filters, token) {
-	let request = {
+  let request = {
     method: 'get',
     url: `${ROOT_URL}/articles`,
-		withCredentials: true,
+    withCredentials: true,
     params: filters
   };
 
-	if (token) {
-		request.headers = { 'Authorization': token };
-	}
+  if (token) {
+    request.headers = { 'Authorization': token };
+  }
   return {
     type: FETCH_ARTICLES,
     payload: axios(request)

--- a/src/app/components/common/tagbar/Tagbar.jsx
+++ b/src/app/components/common/tagbar/Tagbar.jsx
@@ -8,10 +8,10 @@ export default class Tagbar extends Component {
           <div className="container">
             <ul className="nav navbar-nav navbar-left">
                 <li><Link to="/">Home</Link></li>
-                <li><Link to="/tag/academics">Academic</Link></li>
-                <li><Link to="/tag/social">Social</Link></li>
-                <li><Link to="/tag/politics">Politics</Link></li>
-                <li><Link to="/tag/election">Election</Link></li>
+                <li><Link to="/tag/Academics">Academic</Link></li>
+                <li><Link to="/tag/Social">Social</Link></li>
+                <li><Link to="/tag/Politics">Politics</Link></li>
+                <li><Link to="/tag/Election">Election</Link></li>
               </ul>
             </div>
         </nav>

--- a/src/app/components/homeFeed/HomeFeed.jsx
+++ b/src/app/components/homeFeed/HomeFeed.jsx
@@ -7,7 +7,7 @@ export default class HomeFeed extends Component {
   render() {
     return (
       <div className="main-container">
-        <ArticlesListContainer />
+        <ArticlesListContainer filters={{}}/>
       </div>
     );
   }

--- a/src/app/components/tagView/TagView.jsx
+++ b/src/app/components/tagView/TagView.jsx
@@ -7,7 +7,7 @@ export default class TagView extends Component {
       <div className="main-container">
         <h3>Articles about {this.props.params.id}</h3>
         <div className="header-line"></div>
-        <ArticlesListContainer tag={this.props.params.id}/>
+        <ArticlesListContainer filters={{tag: this.props.params.id}}/>
       </div>
     );
   }

--- a/src/app/containers/ArticlesListContainer.js
+++ b/src/app/containers/ArticlesListContainer.js
@@ -12,12 +12,8 @@ const mapStateToProps = (state, currentProps) => {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  let filters = {};
-  if (ownProps.tag) {
-    filters.tag = ownProps.tag
-  };
   return {
-    filters: filters,
+    filters: ownProps.filters,
     fetchArticles: (filters, token) => {
       return new Promise (() => {
         let response = dispatch(fetchArticles(filters, token));


### PR DESCRIPTION
`ArticlesListContainer` now takes a `filters` prop that gets passed to the `fetchArticles` action. This is highly extensible. For example, when the user selects a specific year on the filter box, we simply need to add something like `year: 2017` to the filters object.

Also, I capitalized the links on the `Tagbar` because otherwise they showed as lowercase on the Tag View page.